### PR TITLE
Rd examples include now 'dontrun' where commented out

### DIFF
--- a/man/bigDivPart.Rd
+++ b/man/bigDivPart.Rd
@@ -71,8 +71,10 @@ Weir, B.S. & Cockerham, C.C., Estimating F-Statistics, for the Analysis of Popul
 \author{Kevin Keenan <kkeenan02@qub.ac.uk>}
 
 \examples{
+\dontrun{
 # simply use the following format to run the function
-# 
-# test_result <- bigDivPart(infile = 'mydata', outfile = "myresults',
-#                           WC_Fst = TRUE, format = "txt")
+ 
+test_result <- bigDivPart(infile = 'mydata', outfile = "myresults',
+                          WC_Fst = TRUE, format = "txt")
+}
 }

--- a/man/chiCalc.Rd
+++ b/man/chiCalc.Rd
@@ -46,9 +46,11 @@ Kevin Keenan <kkeenan02@qub.ac.uk>
 }
 
 \examples{
+\dontrun{
 # To run an example use the following format
-# library(diveRsity)
-# data(Test_data)
-# test_results <- chiCalc(infile = Test_data, outfile = NULL,
-#                          pairwise = TRUE, mcRep = 5000)
+library(diveRsity)
+data(Test_data)
+test_results <- chiCalc(infile = Test_data, outfile = NULL,
+                        pairwise = TRUE, mcRep = 5000)
+}
 }

--- a/man/diffCalc.Rd
+++ b/man/diffCalc.Rd
@@ -92,12 +92,14 @@ Weir, B.S. & Cockerham, C.C., Estimating F-Statistics, for the Analysis of Popul
 \author{Kevin Keenan <kkeenan02@qub.ac.uk>}
 
 \examples{
+\dontrun{
 # simply use the following format to run the function
-# library(diveRsity)
-# data(Test_data)
-# Test_data[is.na(Test_data)] <- ""
-#
-# test_result <- diffCalc(infile = Test_data, outfile = "myresults",
-#                         fst = TRUE, pairwise = TRUE, bs_locus = TRUE,
-#                         bs_pairwise = TRUE, boots = 1000, para = TRUE)
+library(diveRsity)
+data(Test_data)
+Test_data[is.na(Test_data)] <- ""
+
+test_result <- diffCalc(infile = Test_data, outfile = "myresults",
+                        fst = TRUE, pairwise = TRUE, bs_locus = TRUE,
+                        bs_pairwise = TRUE, boots = 1000, para = TRUE)
+}
 }

--- a/man/divBasic.Rd
+++ b/man/divBasic.Rd
@@ -66,7 +66,9 @@ Kevin Keenan <kkeenan02@qub.ac.uk>
 }
 
 \examples{
+\dontrun{
 # To run an example use the following format
-#
-# test_results <- divBasic(infile = Test_data, outfile = 'out', gp = 3, bootstraps = 1000)
+
+test_results <- divBasic(infile = Test_data, outfile = 'out', gp = 3, bootstraps = 1000)
+}
 }

--- a/man/divPart.Rd
+++ b/man/divPart.Rd
@@ -92,10 +92,12 @@ Weir, B.S. & Cockerham, C.C., Estimating F-Statistics, for the Analysis of Popul
 \author{Kevin Keenan <kkeenan02@qub.ac.uk>}
 
 \examples{
+\dontrun{
 # simply use the following format to run the function
-# 
-# test_result <- divPart(infile = 'mydata', outfile = "myresults', 
-#                        gp = 3, pairwise = TRUE, bs_locus = TRUE, 
-#                        bs_pairwise = TRUE, bootstraps = 1000, 
-#                        plot = TRUE)
+ 
+test_result <- divPart(infile = 'mydata', outfile = "myresults', 
+                       gp = 3, pairwise = TRUE, bs_locus = TRUE, 
+                       bs_pairwise = TRUE, bootstraps = 1000, 
+                       plot = TRUE)
+}
 }

--- a/man/divRatio.Rd
+++ b/man/divRatio.Rd
@@ -65,9 +65,11 @@ Kevin Keenan <kkeenan02@qub.ac.uk>
 }
 
 \examples{
+\dontrun{
 # To run an example use the following format
-#
-# test_results <- divBasic(infile = Test_data, outfile = 'out', 
-#                          gp = 3, pop_stats = NULL, refPos = NULL, 
-#                          bootstraps = 1000, parallel = TRUE)
-#}
+
+test_results <- divBasic(infile = Test_data, outfile = 'out', 
+                         gp = 3, pop_stats = NULL, refPos = NULL, 
+                         bootstraps = 1000, parallel = TRUE)
+}
+}

--- a/man/fastDivPart.Rd
+++ b/man/fastDivPart.Rd
@@ -90,10 +90,12 @@ Weir, B.S. & Cockerham, C.C., Estimating F-Statistics, for the Analysis of Popul
 \author{Kevin Keenan <kkeenan02@qub.ac.uk>}
 
 \examples{
+\dontrun{
 # simply use the following format to run the function
-# 
-# test_result <- fastDivPart(infile = 'mydata', outfile = "myresults', 
-#                            gp = 3, pairwise = TRUE, bs_locus = TRUE, 
-#                            bs_pairwise = TRUE, bootstraps = 1000, 
-#                            plot = TRUE)
+
+test_result <- fastDivPart(infile = 'mydata', outfile = "myresults', 
+                           gp = 3, pairwise = TRUE, bs_locus = TRUE, 
+                           bs_pairwise = TRUE, bootstraps = 1000, 
+                           plot = TRUE)
+}
 }

--- a/man/inCalc.Rd
+++ b/man/inCalc.Rd
@@ -70,11 +70,13 @@ Kevin Keenan <kkeenan02@qub.ac.uk>
 }
 
 \examples{
+\dontrun{
 # To run an example use the following format
-# library(diveRsity)
-# data(Test_data)
-# Test_data[is.na(Test_data)] <- ""
-#
-# test_results<-inCalc(infile = Test_data, outfile = 'out', pairwise = TRUE,
-#                      xlsx = FALSE, boots = 1000, para = TRUE)
+library(diveRsity)
+data(Test_data)
+Test_data[is.na(Test_data)] <- ""
+
+test_results<-inCalc(infile = Test_data, outfile = 'out', pairwise = TRUE,
+                     xlsx = FALSE, boots = 1000, para = TRUE)
+}
 }

--- a/man/snp2gen.Rd
+++ b/man/snp2gen.Rd
@@ -25,7 +25,8 @@ Kevin Keenan, 2014
 
 
 \examples{
-## NOT RUN
-# data(SNPs, package = "diveRsity")
-# snp2gen(infile = SNPs, prefix_length = 2, write = FALSE)
+\dontrun{
+data(SNPs, package = "diveRsity")
+snp2gen(infile = SNPs, prefix_length = 2, write = FALSE)
+}
 }


### PR DESCRIPTION
Included the **\dontrun{}** command where code in the *examples* section of the *Rd* files was commented out. 
Now the user can more easily copy paste the examples to the console.